### PR TITLE
Push players upwards when falling in void in spawn

### DIFF
--- a/src/com/leontg77/ultrahardcore/Main.java
+++ b/src/com/leontg77/ultrahardcore/Main.java
@@ -1,8 +1,6 @@
 package com.leontg77.ultrahardcore;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -23,7 +21,6 @@ import com.leontg77.ultrahardcore.commands.CommandHandler;
 import com.leontg77.ultrahardcore.feature.FeatureManager;
 import com.leontg77.ultrahardcore.feature.health.GoldenHeadsFeature;
 import com.leontg77.ultrahardcore.feature.portal.NetherFeature;
-import com.leontg77.ultrahardcore.feature.pvp.StalkingFeature;
 import com.leontg77.ultrahardcore.gui.GUIManager;
 import com.leontg77.ultrahardcore.listeners.ChatListener;
 import com.leontg77.ultrahardcore.listeners.LoginListener;
@@ -220,7 +217,7 @@ public class Main extends JavaPlugin {
 		manager.registerEvents(new LoginListener(this, game, settings, spec, scatter, perm), this);
 		manager.registerEvents(new LogoutListener(this, game, gui, spec, perm), this);
 		manager.registerEvents(new PlayerListener(this, spec), this);
-		manager.registerEvents(new ProtectionListener(game), this);
+		manager.registerEvents(new ProtectionListener(game, parkour), this);
 		manager.registerEvents(new SpectatorListener(game, spec, gui, feat.getFeature(NetherFeature.class)), this);
 		manager.registerEvents(new StatsListener(this, arena, game, board, teams, feat.getFeature(GoldenHeadsFeature.class)), this);
 		manager.registerEvents(new WorldListener(arena), this);

--- a/src/com/leontg77/ultrahardcore/listeners/ParkourListener.java
+++ b/src/com/leontg77/ultrahardcore/listeners/ParkourListener.java
@@ -106,12 +106,12 @@ public class ParkourListener implements Listener {
 		}
 		
 		final Player player = event.getPlayer();
-		
+
 		if (spec.isSpectating(player)) {
 			return;
 		}
 			
-		if (to.getBlockY() < 20) {
+		if (to.getBlockY() < 20 && parkour.isParkouring(player)) {
 			player.teleport(parkour.getLocation(parkour.getCheckpoint(player)), TeleportCause.UNKNOWN);
 			return;
 		}

--- a/src/com/leontg77/ultrahardcore/listeners/ProtectionListener.java
+++ b/src/com/leontg77/ultrahardcore/listeners/ProtectionListener.java
@@ -1,5 +1,7 @@
 package com.leontg77.ultrahardcore.listeners;
 
+import com.leontg77.ultrahardcore.Parkour;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -18,6 +20,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.leontg77.ultrahardcore.Game;
 import com.leontg77.ultrahardcore.State;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.util.Vector;
 
 /**
  * Protection listener class.
@@ -28,14 +32,17 @@ import com.leontg77.ultrahardcore.State;
  */
 public class ProtectionListener implements Listener {
 	private final Game game;
+	private final Parkour parkour;
 	
 	/**
 	 * Player listener class constructor.
-	 * 
+	 *
 	 * @param game The game class.
+	 * @param parkour The parkour instance
 	 */
-	public ProtectionListener(Game game) {
+	public ProtectionListener(Game game, Parkour parkour) {
 		this.game = game;
+		this.parkour = parkour;
 	}
 	
 	@EventHandler
@@ -83,6 +90,23 @@ public class ProtectionListener implements Listener {
 
 		event.setCancelled(true);
     }
+
+	@EventHandler
+	public void on(PlayerMoveEvent event) {
+		Location to = event.getTo();
+		World world = to.getWorld();
+		Player player = event.getPlayer();
+		Vector velocity = player.getVelocity();
+		double velocityY = velocity.getY();
+
+		if (!world.getName().equals("lobby")) return;
+		if (to.getY() > 20) return;
+		if (parkour.isParkouring(player)) return;
+		if (velocityY > 2) return;
+
+		velocity.setY(velocityY + 2);
+		player.setVelocity(velocity);
+	}
 	
 	@EventHandler
     public void on(PlayerInteractEvent event) {


### PR DESCRIPTION
This also moves relevant logic from ParkourListener to ProtectionListener, as previously void teleporting in spawn was handled by parkour.