### PR TITLE
Add global chat command

### DIFF
--- a/src/com/leontg77/ultrahardcore/commands/CommandHandler.java
+++ b/src/com/leontg77/ultrahardcore/commands/CommandHandler.java
@@ -3,6 +3,8 @@ package com.leontg77.ultrahardcore.commands;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.leontg77.ultrahardcore.commands.spectate.GlobalChatCommand;
+import com.leontg77.ultrahardcore.commands.spectate.GoodGameCommand;
 import com.leontg77.ultrahardcore.commands.spectate.SpectatorChatProtectionCommand;
 import com.leontg77.ultrahardcore.commands.user.SetFixedScatterLocationCommand;
 import org.bukkit.ChatColor;
@@ -293,6 +295,9 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 
 		// spectate
 		cmds.add(new BackCommand(plugin, spec));
+		GlobalChatCommand globalChatCommand = new GlobalChatCommand(plugin, game, spec);
+		cmds.add(globalChatCommand);
+		cmds.add(new GoodGameCommand(globalChatCommand));
 		cmds.add(new InvseeCommand(gui, spec));
 		cmds.add(new NearCommand(spec, teams));
 		cmds.add(new SpectateCommand(game, spec));

--- a/src/com/leontg77/ultrahardcore/commands/spectate/GlobalChatCommand.java
+++ b/src/com/leontg77/ultrahardcore/commands/spectate/GlobalChatCommand.java
@@ -1,0 +1,79 @@
+package com.leontg77.ultrahardcore.commands.spectate;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.leontg77.ultrahardcore.Game;
+import com.leontg77.ultrahardcore.Main;
+import com.leontg77.ultrahardcore.User;
+import com.leontg77.ultrahardcore.commands.CommandException;
+import com.leontg77.ultrahardcore.commands.UHCCommand;
+import com.leontg77.ultrahardcore.managers.SpecManager;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Set;
+
+public class GlobalChatCommand extends UHCCommand {
+
+    protected final Main plugin;
+    protected final Game game;
+    protected final SpecManager manager;
+
+    public GlobalChatCommand(Main plugin, Game game, SpecManager manager) {
+        super("g", "<message>");
+        this.plugin = plugin;
+        this.game = game;
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) throws CommandException {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(Main.PREFIX + "Only players can use the global chat command-");
+            return true;
+        }
+
+        Player player = (Player) sender;
+        if (!manager.isSpectating(player)) {
+            sender.sendMessage(Main.PREFIX + "You are not spectating.");
+            return true;
+        }
+
+        Set<String> specChatProtected = manager.getSpecChatProtected();
+
+        String name = player.getName();
+        if (!specChatProtected.contains(name)) {
+            sender.sendMessage(Main.PREFIX + "You do not have spectator chat protection enabled.");
+            return true;
+        }
+
+        if (args.length == 0) {
+            return false;
+        }
+
+        String message = Joiner.on(' ').join(args);
+        if (message.startsWith("/")) {
+            sender.sendMessage(Main.PREFIX + "You cannot start a message with the command slash.");
+            return true;
+        }
+
+        if (!message.equalsIgnoreCase("gg")
+                && plugin.getUser(player).getRank() == User.Rank.DEFAULT
+                && !game.isPrivateGame()
+                && !game.isRecordedRound()) {
+            sender.sendMessage(Main.PREFIX + "You may not talk in global chat.");
+            return true;
+        }
+
+        specChatProtected.remove(name);
+        player.chat(message);
+        specChatProtected.add(name);
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return ImmutableList.of();
+    }
+}

--- a/src/com/leontg77/ultrahardcore/commands/spectate/GoodGameCommand.java
+++ b/src/com/leontg77/ultrahardcore/commands/spectate/GoodGameCommand.java
@@ -1,0 +1,28 @@
+package com.leontg77.ultrahardcore.commands.spectate;
+
+import com.google.common.collect.ImmutableList;
+import com.leontg77.ultrahardcore.commands.CommandException;
+import com.leontg77.ultrahardcore.commands.UHCCommand;
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+public class GoodGameCommand extends UHCCommand {
+
+    protected final GlobalChatCommand globalChatCommand;
+
+    public GoodGameCommand(GlobalChatCommand globalChatCommand) {
+        super("gg", "");
+        this.globalChatCommand = globalChatCommand;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) throws CommandException {
+        return globalChatCommand.execute(sender, new String[]{"gg"});
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        return ImmutableList.of();
+    }
+}

--- a/src/com/leontg77/ultrahardcore/listeners/SpectatorListener.java
+++ b/src/com/leontg77/ultrahardcore/listeners/SpectatorListener.java
@@ -72,10 +72,6 @@ public class SpectatorListener implements Listener {
 
 	@EventHandler
 	public void on(AsyncPlayerChatEvent event) {
-		if (game.isPrivateGame() || game.isRecordedRound()) {
-			return;
-		}
-		
 		Player player = event.getPlayer();
 		
 		if (!spec.isSpectating(player)) {
@@ -87,10 +83,6 @@ public class SpectatorListener implements Listener {
 		}
 
 		String message = event.getMessage();
-		
-		if (message.equalsIgnoreCase("gg")) {
-			return;
-		}
 		
 		event.setCancelled(true);
 		Bukkit.getScheduler().runTask(plugin, () -> player.performCommand("sc " + message));

--- a/src/com/leontg77/ultrahardcore/managers/PermissionsManager.java
+++ b/src/com/leontg77/ultrahardcore/managers/PermissionsManager.java
@@ -124,7 +124,9 @@ public class PermissionsManager {
 		perm.setPermission("uhc.tp", true);
 		perm.setPermission("uhc.back", true);
 		perm.setPermission("uhc.specandstaffchat", true);
-		
+		perm.setPermission("uhc.g", true);
+		perm.setPermission("uhc.gg", true);
+
 		if (UBL_COMMITEE_UUIDS.contains(player.getUniqueId().toString())) {
 			perm.setPermission("uhc.prelist", true);
 			perm.setPermission("uhc.info.ip", true);

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -52,6 +52,10 @@ commands:
     description: Start the firework show.
   fly:
     description: Toggle someones fly mode.
+  g:
+    description: Talk in global chat while having spectator chat protection.
+  gg:
+    description: Alias for '/g gg'.
   gamemode:
     description: Change your gamemode.
     aliases: [gm]


### PR DESCRIPTION
Also move checking logic from listener into command, IMO makes more sense to check it there instead of the listener.

(Let me know if you want "gg" to always go into public chat, I think making it a command is a bit more secure though, spectators might say "gg" when they have 3 clips on a cheater.)