### PR TITLE
Chunk modification performance improvements

### DIFF
--- a/src/com/leontg77/ultrahardcore/feature/world/BiomebasedWoodFeature.java
+++ b/src/com/leontg77/ultrahardcore/feature/world/BiomebasedWoodFeature.java
@@ -36,227 +36,151 @@ public class BiomebasedWoodFeature extends Feature implements Listener {
         final Chunk chunk = event.getChunk();
         physics = false; // for doors not to pop off during setting
 
-        for (int y = 0; y < 256; y++) {
+        // Declaring variables before loop instead of declare+assign in loop
+        // Fuck knows if that helps, but maybe it does
+        Block block;
+        Biome biome;
+        byte oldData;
+        Material oldMaterial;
+
+        byte logData;
+        byte woodData;
+        Material logMaterial;
+        Material fenceMaterial;
+        Material fenceGateMaterial;
+        Material doorMaterial;
+        Material stairMaterial;
+
+        // y < 128: There will probably not be a village/etc. above y = 128
+        for (int y = 0; y < 128; y++) {
             for (int x = 0; x < 16; x++) {
                 for (int z = 0; z < 17; z++) {
-                    handleBlock(chunk.getBlock(x, y, z));
+                    // Yes this is ugly compared to a handle method,
+                    // but I don't think the JVM inlines so long methods
+
+                    block = chunk.getBlock(x, y, z);
+                    biome = block.getBiome();
+                    oldData = block.getData();
+                    oldMaterial = block.getType();
+
+                    logMaterial = Material.LOG;
+                    switch (biome) {
+                        case BIRCH_FOREST:
+                        case BIRCH_FOREST_HILLS:
+                        case BIRCH_FOREST_HILLS_MOUNTAINS:
+                        case BIRCH_FOREST_MOUNTAINS:
+                            logData = 2;
+                            woodData = 2;
+                            fenceMaterial = Material.BIRCH_FENCE;
+                            fenceGateMaterial = Material.BIRCH_FENCE_GATE;
+                            doorMaterial = Material.BIRCH_DOOR;
+                            stairMaterial = Material.BIRCH_WOOD_STAIRS;
+                            break;
+                        case JUNGLE:
+                        case JUNGLE_EDGE:
+                        case JUNGLE_EDGE_MOUNTAINS:
+                        case JUNGLE_HILLS:
+                        case JUNGLE_MOUNTAINS:
+                            logData = 3;
+                            woodData = 3;
+                            fenceMaterial = Material.JUNGLE_FENCE;
+                            fenceGateMaterial = Material.JUNGLE_FENCE_GATE;
+                            doorMaterial = Material.JUNGLE_DOOR;
+                            stairMaterial = Material.JUNGLE_WOOD_STAIRS;
+                            break;
+                        case ROOFED_FOREST:
+                        case ROOFED_FOREST_MOUNTAINS:
+                            logData = 1;
+                            woodData = 5;
+                            logMaterial = Material.LOG_2;
+                            fenceMaterial = Material.DARK_OAK_FENCE;
+                            fenceGateMaterial = Material.DARK_OAK_FENCE_GATE;
+                            doorMaterial = Material.DARK_OAK_DOOR;
+                            stairMaterial = Material.DARK_OAK_STAIRS;
+                            break;
+                        case SAVANNA:
+                        case SAVANNA_MOUNTAINS:
+                        case SAVANNA_PLATEAU:
+                        case SAVANNA_PLATEAU_MOUNTAINS:
+                            logData = 0;
+                            woodData = 4;
+                            logMaterial = Material.LOG_2;
+                            fenceMaterial = Material.ACACIA_FENCE;
+                            fenceGateMaterial = Material.ACACIA_FENCE_GATE;
+                            doorMaterial = Material.ACACIA_DOOR;
+                            stairMaterial = Material.ACACIA_STAIRS;
+                            break;
+                        case TAIGA:
+                        case TAIGA_HILLS:
+                        case TAIGA_MOUNTAINS:
+                        case MEGA_SPRUCE_TAIGA:
+                        case MEGA_SPRUCE_TAIGA_HILLS:
+                        case MEGA_TAIGA:
+                        case MEGA_TAIGA_HILLS:
+                        case COLD_TAIGA:
+                        case COLD_TAIGA_HILLS:
+                        case COLD_TAIGA_MOUNTAINS:
+                            logData = 1;
+                            woodData = 1;
+                            fenceMaterial = Material.SPRUCE_FENCE;
+                            fenceGateMaterial = Material.SPRUCE_FENCE_GATE;
+                            doorMaterial = Material.SPRUCE_DOOR;
+                            stairMaterial = Material.SPRUCE_WOOD_STAIRS;
+                            break;
+                        case DESERT:
+                        case DESERT_HILLS:
+                        case DESERT_MOUNTAINS:
+                            if (block.getType() == Material.LOG) {
+                                block.setType(Material.SANDSTONE);
+                                continue;
+                            }
+
+                            logData = 2;
+                            woodData = 2;
+                            fenceMaterial = Material.BIRCH_FENCE;
+                            fenceGateMaterial = Material.BIRCH_FENCE_GATE;
+                            doorMaterial = Material.BIRCH_DOOR;
+                            stairMaterial = Material.SANDSTONE_STAIRS;
+                            break;
+                        default:
+                            continue;
+                    }
+
+                    switch (oldMaterial) {
+                        case LOG:
+                        case LOG_2:
+                            if (oldMaterial != logMaterial) {
+                                block.setType(logMaterial);
+                            }
+
+                            block.setData(logData);
+                            block.getState().update(true);
+                            break;
+                        case WOOD:
+                            block.setData(woodData);
+                            block.getState().update(true);
+                            break;
+                        case FENCE:
+                            block.setType(fenceMaterial);
+                            block.setData(oldData);
+                            break;
+                        case FENCE_GATE:
+                            block.setType(fenceGateMaterial);
+                            block.setData(oldData);
+                            break;
+                        case WOODEN_DOOR:
+                            block.setType(doorMaterial);
+                            block.setData(oldData);
+                            break;
+                        case WOOD_STAIRS:
+                            block.setType(stairMaterial);
+                            block.setData(oldData);
+                            break;
+                    }
                 }
             }
         }
 
         physics = true;
-    }
-
-    /**
-     * Handle the given block to the right wood type.
-     * 
-     * @param block The block to handle
-     */
-    private void handleBlock(Block block) {
-        Biome biome = block.getBiome();
-        byte oldData = block.getData();
-
-        switch (biome) {
-        case BIRCH_FOREST:
-        case BIRCH_FOREST_HILLS:
-        case BIRCH_FOREST_HILLS_MOUNTAINS:
-        case BIRCH_FOREST_MOUNTAINS:
-            switch (block.getType()) {
-            case LOG:
-            case WOOD:
-                block.setData((byte) 2);
-                block.getState().update(true);
-                break;
-            case FENCE:
-                block.setType(Material.BIRCH_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.BIRCH_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.BIRCH_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.BIRCH_WOOD_STAIRS);
-                block.setData(oldData);
-                break;
-            default:
-                break;
-            }
-            break;
-        case JUNGLE:
-        case JUNGLE_EDGE:
-        case JUNGLE_EDGE_MOUNTAINS:
-        case JUNGLE_HILLS:
-        case JUNGLE_MOUNTAINS:
-            switch (block.getType()) {
-            case LOG:
-            case WOOD:
-                block.setData((byte) 3);
-                block.getState().update(true);
-                break;
-            case FENCE:
-                block.setType(Material.JUNGLE_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.JUNGLE_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.JUNGLE_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.JUNGLE_WOOD_STAIRS);
-                block.setData(oldData);
-                break;
-            default:
-                break;
-            }
-            break;
-        case ROOFED_FOREST:
-        case ROOFED_FOREST_MOUNTAINS:
-            switch (block.getType()) {
-            case LOG:
-                block.setType(Material.LOG_2);
-                block.setData((byte) 1);
-                block.getState().update(true);
-                break;
-            case LOG_2:
-                block.setData((byte) 1);
-                block.getState().update(true);
-                break;
-            case WOOD:
-                block.setData((byte) 5);
-                block.getState().update(true);
-                break;
-            case FENCE:
-                block.setType(Material.DARK_OAK_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.DARK_OAK_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.DARK_OAK_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.DARK_OAK_STAIRS);
-                block.setData(oldData);
-                break;
-            default:
-                break;
-            }
-            break;
-        case SAVANNA:
-        case SAVANNA_MOUNTAINS:
-        case SAVANNA_PLATEAU:
-        case SAVANNA_PLATEAU_MOUNTAINS:
-            switch (block.getType()) {
-            case LOG:
-                block.setType(Material.LOG_2);
-                block.setData((byte) 0);
-                block.getState().update(true);
-                break;
-            case LOG_2:
-                block.setData((byte) 0);
-                block.getState().update(true);
-                break;
-            case WOOD:
-                block.setData((byte) 4);
-                block.getState().update(true);
-                break;
-            case FENCE:
-                block.setType(Material.ACACIA_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.ACACIA_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.ACACIA_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.ACACIA_STAIRS);
-                block.setData(oldData);
-                break;
-            default:
-                break;
-            }
-            break;
-        case TAIGA:
-        case TAIGA_HILLS:
-        case TAIGA_MOUNTAINS:
-        case MEGA_SPRUCE_TAIGA:
-        case MEGA_SPRUCE_TAIGA_HILLS:
-        case MEGA_TAIGA:
-        case MEGA_TAIGA_HILLS:
-        case COLD_TAIGA:
-        case COLD_TAIGA_HILLS:
-        case COLD_TAIGA_MOUNTAINS:
-            switch (block.getType()) {
-            case LOG:
-            case WOOD:
-                block.setData((byte) 1);
-                block.getState().update(true);
-                break;
-            case FENCE:
-                block.setType(Material.SPRUCE_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.SPRUCE_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.SPRUCE_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.SPRUCE_WOOD_STAIRS);
-                block.setData(oldData);
-                break;
-            default: 
-                break;
-            }
-            break;
-        case DESERT:
-        case DESERT_HILLS:
-        case DESERT_MOUNTAINS:
-            switch (block.getType()) {
-            case WOOD:
-                block.setType(Material.SANDSTONE);
-                break;
-            case FENCE:
-                block.setType(Material.BIRCH_FENCE);
-                block.setData(oldData);
-                break;
-            case FENCE_GATE:
-                block.setType(Material.BIRCH_FENCE_GATE);
-                block.setData(oldData);
-                break;
-            case WOODEN_DOOR:
-                block.setType(Material.BIRCH_DOOR);
-                block.setData(oldData);
-                break;
-            case WOOD_STAIRS:
-                block.setType(Material.SANDSTONE_STAIRS);
-                block.setData(oldData);
-                break;
-            default:
-                break;
-            }
-            break;
-        default:
-            break;
-        }
     }
 }

--- a/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
+++ b/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
@@ -64,6 +64,10 @@ public class AntiStripmine implements Listener {
                             .map(BlockUtils::getNearby)
                             .forEach(nearbyBlocks::addAll);
 
+                    // BlockUtils#getNearby on a vein will obviously catch the other vein blocks too,
+                    // so remove all vein blocks from the nearby block set.
+                    nearbyBlocks.removeAll(anyOreVein);
+
                     boolean nearbyEmptyOrLiquid = nearbyBlocks.stream()
                             .anyMatch(near -> near.isEmpty() || near.isLiquid());
 

--- a/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
+++ b/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
@@ -45,12 +45,13 @@ public class AntiStripmine implements Listener {
             for (int z = 0; z < 16; z++) {
                 for (int y = 0; y < 32; y++) {
                     Block block = chunk.getBlock(x, y, z);
-                    Material type = block.getType();
-                    if (!DEFAULT_ORES.contains(type)) {
+
+                    if (checked.contains(block)) {
                         continue;
                     }
 
-                    if (checked.contains(block)) {
+                    Material type = block.getType();
+                    if (!DEFAULT_ORES.contains(type)) {
                         continue;
                     }
 

--- a/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
+++ b/src/com/leontg77/ultrahardcore/world/antistripmine/AntiStripmine.java
@@ -59,9 +59,12 @@ public class AntiStripmine implements Listener {
 
                     checked.addAll(anyOreVein);
 
-                    boolean nearbyEmptyOrLiquid = anyOreVein.stream()
+                    Set<Block> nearbyBlocks = Sets.newHashSet();
+                    anyOreVein.stream()
                             .map(BlockUtils::getNearby)
-                            .flatMap(List::stream)
+                            .forEach(nearbyBlocks::addAll);
+
+                    boolean nearbyEmptyOrLiquid = nearbyBlocks.stream()
                             .anyMatch(near -> near.isEmpty() || near.isLiquid());
 
                     if (nearbyEmptyOrLiquid) {

--- a/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
+++ b/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
@@ -50,7 +50,7 @@ public class OreLimiter implements Listener {
         Set<Block> checked = Sets.newHashSet();
 
         for (int x = 0; x < 16; x++) {
-            for (int y = 0; y < 256; y++) {
+            for (int y = 0; y < 32; y++) {
                 for (int z = 0; z < 16; z++) {
                     Block block = chunk.getBlock(x, y, z);
 


### PR DESCRIPTION
Copied from commit:

- AntiStripmine: Store nearby blocks of ore veins in a set to remove overlaps and unneeded checking on the same blocks
- BiomebasedWoodFeature: Full rework
- OreLimiter: Loop up to y=32 instead of y=256 (derp)