### PR TITLE
OreLimiter rework

### DIFF
--- a/src/com/leontg77/ultrahardcore/Main.java
+++ b/src/com/leontg77/ultrahardcore/Main.java
@@ -182,7 +182,7 @@ public class Main extends JavaPlugin {
         swap = new BiomeSwap(this, settings);
         swap.setup();
 
-        oreLimiter = new OreLimiter();
+        oreLimiter = new OreLimiter(settings);
         antiSM = new AntiStripmine(settings);
 
         worlds = new WorldManager(settings);

--- a/src/com/leontg77/ultrahardcore/gui/guis/GameInfoGUI.java
+++ b/src/com/leontg77/ultrahardcore/gui/guis/GameInfoGUI.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -545,8 +546,14 @@ public class GameInfoGUI extends GUI implements Listener {
         } else{
             OreLimiter.Type oreLimiter = OreLimiter.Type.valueOf(settings.getWorlds().getString(
                     game.getWorld().getName() + ".oreLimiter", OreLimiter.Type.NONE.name()));
+            List<String> additionalLore = oreLimiter.getAdditionalLore();
+            if (oreLimiter == OreLimiter.Type.MINOR) {
+                // Hide lore in info GUI for MINOR type
+                additionalLore = ImmutableList.of();
+            }
+
             lore.add("§8» §7Ore Limiter: " + oreLimiter.getShortDescription());
-            lore.addAll(Lists.transform(oreLimiter.getAdditionalLore(), "   §8» "::concat));
+            lore.addAll(Lists.transform(additionalLore, "   §8» "::concat));
             lore.add(" ");
         }
 

--- a/src/com/leontg77/ultrahardcore/gui/guis/GameInfoGUI.java
+++ b/src/com/leontg77/ultrahardcore/gui/guis/GameInfoGUI.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import com.google.common.collect.Lists;
 import com.leontg77.ultrahardcore.Game;
 import com.leontg77.ultrahardcore.Game.State;
 import com.leontg77.ultrahardcore.Main;
@@ -64,6 +65,7 @@ import com.leontg77.ultrahardcore.utils.DateUtils;
 import com.leontg77.ultrahardcore.utils.FileUtils;
 import com.leontg77.ultrahardcore.utils.NameUtils;
 import com.leontg77.ultrahardcore.utils.NumberUtils;
+import com.leontg77.ultrahardcore.world.orelimiter.OreLimiter;
 
 /**
  * GameInfo inventory GUI class.
@@ -536,9 +538,18 @@ public class GameInfoGUI extends GUI implements Listener {
         lore.add(" ");
         lore.add("§8» §7Nerfed XP: " + (feat.getFeature(NerfedXPFeature.class).isEnabled() ? "§aEnabled." : "§cDisabled."));
         lore.add(" ");
-        lore.add("§8» §7Ore Limiter: §6" + (game.getWorld() == null ? "§cN/A" : settings.getWorlds().getBoolean(game.getWorld().getName() + ".oreLimiter", false) ? "§aEnabled." : "§cDisabled."));
         lore.add("§8» §71.8 Stone: §6" + (game.getWorld() == null ? "§cN/A" : settings.getWorlds().getBoolean(game.getWorld().getName() + ".newStone", false) ? "§aEnabled." : "§cDisabled."));
-        lore.add(" ");
+
+        if (game.getWorld() == null) {
+            lore.add("§8» §7Ore Limiter: §cN/A");
+        } else{
+            OreLimiter.Type oreLimiter = OreLimiter.Type.valueOf(settings.getWorlds().getString(
+                    game.getWorld().getName() + ".oreLimiter", OreLimiter.Type.NONE.name()));
+            lore.add("§8» §7Ore Limiter: " + oreLimiter.getShortDescription());
+            lore.addAll(Lists.transform(oreLimiter.getAdditionalLore(), "   §8» "::concat));
+            lore.add(" ");
+        }
+
         miscIMeta.setLore(lore);
         misc.setItemMeta(miscIMeta);
         lore.clear();

--- a/src/com/leontg77/ultrahardcore/gui/guis/WorldCreatorGUI.java
+++ b/src/com/leontg77/ultrahardcore/gui/guis/WorldCreatorGUI.java
@@ -18,9 +18,11 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import com.google.common.collect.Lists;
 import com.leontg77.ultrahardcore.Main;
 import com.leontg77.ultrahardcore.gui.GUI;
 import com.leontg77.ultrahardcore.utils.NameUtils;
+import com.leontg77.ultrahardcore.world.orelimiter.OreLimiter;
 import com.leontg77.ultrahardcore.world.WorldManager;
 
 /**
@@ -57,7 +59,7 @@ public class WorldCreatorGUI extends GUI implements Listener {
 
     private boolean newstone = false;
     private boolean antiStripmine = true;
-    private boolean orelimiter = true;
+    private OreLimiter.Type orelimiter = OreLimiter.Type.MINOR;
 
     private boolean moved = true;
 
@@ -75,7 +77,7 @@ public class WorldCreatorGUI extends GUI implements Listener {
         if (inv.getViewers().isEmpty()) {
             newstone = false;
             antiStripmine = true;
-            orelimiter = true;
+            orelimiter = OreLimiter.Type.MINOR;
 
             moved = false;
 
@@ -142,7 +144,20 @@ public class WorldCreatorGUI extends GUI implements Listener {
             update();
             break;
         case "ore limiter":
-            orelimiter = !orelimiter;
+            switch (orelimiter) {
+                case MINOR:
+                    orelimiter = OreLimiter.Type.LESS_VEINS;
+                    break;
+                case LESS_VEINS:
+                    orelimiter = OreLimiter.Type.SMALLER_VEINS;
+                    break;
+                case SMALLER_VEINS:
+                    orelimiter = OreLimiter.Type.MINOR;
+                    break;
+                default:
+                    return;
+            }
+
             update();
             break;
         case "world type":
@@ -252,11 +267,10 @@ public class WorldCreatorGUI extends GUI implements Listener {
 
         oreLimiterMeta.setDisplayName("§8» §6Ore Limiter §8«");
         lore.add(" ");
-        lore.add("§8» §7Currently: " + (orelimiter ? ChatColor.GREEN + "Enabled" : ChatColor.RED + "Disabled"));
+        lore.add("§8» §7Currently: " + orelimiter.getShortDescription());
         lore.add(" ");
         lore.add("§8» §cDescription:");
-        lore.add("§8» §7Limit the amount of cave ores.");
-        lore.add(" ");
+        lore.addAll(Lists.transform(orelimiter.getAdditionalLore(), "§8» "::concat));
         oreLimiterMeta.setLore(lore);
         oreLimiter.setItemMeta(oreLimiterMeta);
 

--- a/src/com/leontg77/ultrahardcore/gui/guis/WorldCreatorGUI.java
+++ b/src/com/leontg77/ultrahardcore/gui/guis/WorldCreatorGUI.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.google.common.collect.ImmutableList;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -264,10 +265,9 @@ public class WorldCreatorGUI extends GUI implements Listener {
 
         ItemStack oreLimiter = new ItemStack(Material.DIAMOND_ORE);
         ItemMeta oreLimiterMeta = oreLimiter.getItemMeta();
-
         oreLimiterMeta.setDisplayName("§8» §6Ore Limiter §8«");
         lore.add(" ");
-        lore.add("§8» §7Currently: " + orelimiter.getShortDescription());
+        lore.add("§8» §7Currently: " + orelimiter.getShortDescription().replace(".", ""));
         lore.add(" ");
         lore.add("§8» §cDescription:");
         lore.addAll(Lists.transform(orelimiter.getAdditionalLore(), "§8» "::concat));

--- a/src/com/leontg77/ultrahardcore/minigames/Arena.java
+++ b/src/com/leontg77/ultrahardcore/minigames/Arena.java
@@ -36,6 +36,7 @@ import com.leontg77.ultrahardcore.managers.ScatterManager;
 import com.leontg77.ultrahardcore.minigames.listeners.ArenaListener;
 import com.leontg77.ultrahardcore.utils.PacketUtils;
 import com.leontg77.ultrahardcore.utils.PlayerUtils;
+import com.leontg77.ultrahardcore.world.orelimiter.OreLimiter;
 import com.leontg77.ultrahardcore.world.WorldManager;
 
 /**
@@ -309,7 +310,7 @@ public class Arena {
         World world = Bukkit.getWorld("arena");
 
         manager.deleteWorld(world);
-        manager.createWorld("arena", 400, SEEDS.get(new Random().nextInt(SEEDS.size())), Environment.NORMAL, WorldType.NORMAL, false, false, false, 0.0, 0.0);
+        manager.createWorld("arena", 400, SEEDS.get(new Random().nextInt(SEEDS.size())), Environment.NORMAL, WorldType.NORMAL, false, OreLimiter.Type.NONE, false, 0.0, 0.0);
 
         world = Bukkit.getWorld("arena");
 

--- a/src/com/leontg77/ultrahardcore/world/WorldManager.java
+++ b/src/com/leontg77/ultrahardcore/world/WorldManager.java
@@ -20,6 +20,7 @@ import com.leontg77.ultrahardcore.Settings;
 import com.leontg77.ultrahardcore.exceptions.CommandException;
 import com.leontg77.ultrahardcore.utils.FileUtils;
 import com.leontg77.ultrahardcore.utils.LocationUtils;
+import com.leontg77.ultrahardcore.world.orelimiter.OreLimiter;
 
 /**
  * World management class.
@@ -71,7 +72,7 @@ public class WorldManager {
      * @param centerX The world X center.
      * @param centerZ The world Z center.
      */
-    public void createWorld(String name, int diameter, long seed, Environment environment, WorldType type, boolean antiStripmine, boolean oreLimiter, boolean newStone, double centerX, double centerZ) {
+    public void createWorld(String name, int diameter, long seed, Environment environment, WorldType type, boolean antiStripmine, OreLimiter.Type oreLimiter, boolean newStone, double centerX, double centerZ) {
         settings.getWorlds().set(name + ".name", name);
         settings.getWorlds().set(name + ".radius", diameter);
         settings.getWorlds().set(name + ".seed", seed);
@@ -81,7 +82,7 @@ public class WorldManager {
         settings.getWorlds().set(name + ".diameter", diameter);
 
         settings.getWorlds().set(name + ".antiStripmine", antiStripmine);
-        settings.getWorlds().set(name + ".oreLimiter", oreLimiter);
+        settings.getWorlds().set(name + ".oreLimiter", oreLimiter.name());
         settings.getWorlds().set(name + ".newStone", newStone);
         settings.getWorlds().set(name + ".center.x", centerX);
         settings.getWorlds().set(name + ".center.z", centerZ);
@@ -145,9 +146,9 @@ public class WorldManager {
 
         Environment environment = Environment.valueOf(settings.getWorlds().getString(name + ".environment", Environment.NORMAL.name()));
         WorldType type = WorldType.valueOf(settings.getWorlds().getString(name + ".worldtype", WorldType.NORMAL.name()));
+        OreLimiter.Type oreLimiter = OreLimiter.Type.valueOf(settings.getWorlds().getString(name + ".oreLimiter", OreLimiter.Type.NONE.name()));
         long seed = settings.getWorlds().getLong(name + ".seed", 2347862349786234l);
         boolean newStone = settings.getWorlds().getBoolean(name + ".newStone", true);
-        boolean oreLimiter = settings.getWorlds().getBoolean(name + ".oreLimiter", false);
 
         WorldCreator creator = new WorldCreator(name);
         creator.generateStructures(true);
@@ -163,7 +164,7 @@ public class WorldManager {
         return world;
     }
 
-    protected String getGeneratorSettings(WorldType worldtype, boolean newStone, boolean oreLimiter) {
+    protected String getGeneratorSettings(WorldType worldtype, boolean newStone, OreLimiter.Type oreLimiter) {
         if (worldtype == WorldType.FLAT) {
             return "3;minecraft:bedrock,2*minecraft:dirt,minecraft:grass;1;village(size=65535 distance=9";
         }
@@ -180,10 +181,10 @@ public class WorldManager {
             }
         }
 
-        if (oreLimiter) {
+        if (oreLimiter == OreLimiter.Type.SMALLER_VEINS) {
             generatorSettings.put("goldSize", 6);
-            generatorSettings.put("redstoneSize", 4);
-            generatorSettings.put("diamondSize", 5);
+            generatorSettings.put("redstoneSize", 6);
+            generatorSettings.put("diamondSize", 6);
         }
 
         return new Gson().toJson(generatorSettings);

--- a/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
+++ b/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
@@ -35,15 +35,15 @@ public class OreLimiter implements Listener {
          * Hosts shall not be able to use this type
          * from the world creator GUI / related.
          */
-        NONE(0.0d, ""),
+        NONE(0.0d, "§cDisabled.", "§7Ores are not limited."),
         /**
          * Impl. note:
-         * Minor is displayed as "None" as players will keep complaining.
+         * Minor is displayed as "Disabled" as players will keep complaining.
          * Make sure to only limit within realm of "not noticable"
          */
-        MINOR(0.2d, "§aNone", "§7Ores are not limited."),
-        LESS_VEINS(0.5d, "§eLess veins", "§e50% §7of gold, diamond and", "§7redstone veins are §eremoved§7."),
-        SMALLER_VEINS(0.0d, "§eSmaller veins", "§7Gold, diamond and redstone", "§7spawn in veins of §e6 or less", "§7(instead of 8 or less).");
+        MINOR(0.2d, "§cDisabled.", "§7Ores are not limited."),
+        LESS_VEINS(0.5d, "§aEnabled. §e(Less veins)", "§e50% §7of gold, diamond and", "§7redstone veins are §eremoved§7."),
+        SMALLER_VEINS(0.0d, "§aEnabled. §e(Smaller veins)", "§7Gold, diamond and redstone", "§7spawn in veins of §e6 or less", "§7(instead of 8 or less).");
 
         private final double oreRemovalChance;
         private final String shortDescription;

--- a/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
+++ b/src/com/leontg77/ultrahardcore/world/orelimiter/OreLimiter.java
@@ -1,14 +1,21 @@
 package com.leontg77.ultrahardcore.world.orelimiter;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.bukkit.Chunk;
 import org.bukkit.Material;
-import org.bukkit.WorldType;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.leontg77.ultrahardcore.Settings;
 import com.leontg77.ultrahardcore.events.ChunkModifiableEvent;
-
-import gnu.trove.map.TObjectDoubleMap;
-import gnu.trove.map.hash.TObjectDoubleHashMap;
+import com.leontg77.ultrahardcore.utils.BlockUtils;
 
 /**
  * Ore Limiter class.
@@ -16,33 +23,62 @@ import gnu.trove.map.hash.TObjectDoubleHashMap;
  * @author D4mnX
  */
 public class OreLimiter implements Listener {
-    protected static final TObjectDoubleMap<Material> ORE_RATES;
-    
-    static {
-        ORE_RATES = new TObjectDoubleHashMap<>();
-        ORE_RATES.put(Material.GOLD_ORE, 0.45d);
-        ORE_RATES.put(Material.DIAMOND_ORE, 0.60d);
-        ORE_RATES.put(Material.REDSTONE_ORE, 0.35d);
+    protected static final Collection<Material> LIMITED_ORES = ImmutableList.of(
+            Material.GOLD_ORE,
+            Material.DIAMOND_ORE,
+            Material.REDSTONE_ORE
+    );
+
+    public enum Type {
+        /**
+         * Impl. note:
+         * Hosts shall not be able to use this type
+         * from the world creator GUI / related.
+         */
+        NONE(0.0d, ""),
+        /**
+         * Impl. note:
+         * Minor is displayed as "None" as players will keep complaining.
+         * Make sure to only limit within realm of "not noticable"
+         */
+        MINOR(0.2d, "§aNone", "§7Ores are not limited."),
+        LESS_VEINS(0.5d, "§eLess veins", "§e50% §7of gold, diamond and", "§7redstone veins are §eremoved§7."),
+        SMALLER_VEINS(0.0d, "§eSmaller veins", "§7Gold, diamond and redstone", "§7spawn in veins of §e6 or less", "§7(instead of 8 or less).");
+
+        private final double oreRemovalChance;
+        private final String shortDescription;
+        private final List<String> additionalLore;
+
+        Type(double oreRemovalChance, String shortDescription, String... additionalLore) {
+            this.oreRemovalChance = oreRemovalChance;
+            this.shortDescription = shortDescription;
+            this.additionalLore = ImmutableList.copyOf(additionalLore);
+        }
+
+        public double getOreRemovalChance() {
+            return oreRemovalChance;
+        }
+
+        public String getShortDescription() {
+            return shortDescription;
+        }
+
+        public List<String> getAdditionalLore() {
+            return additionalLore;
+        }
     }
 
-//    private final Random random = new Random();
-//    private final Settings settings;
-//
-//    public OreLimiter(Settings settings) {
-//        this.settings = settings;
-//    }
+    private final Random random = new Random();
+    private final Settings settings;
 
-    /**
-     * Temporarly disabled and moved into generator settings.
-     * See {@link com.leontg77.ultrahardcore.world.WorldManager#getGeneratorSettings(WorldType, boolean, boolean)}.
-     */
+    public OreLimiter(Settings settings) {
+        this.settings = settings;
+    }
+
     @EventHandler
     public void on(ChunkModifiableEvent event) {
-        /*
-
-        if (!settings.getWorlds().getBoolean(event.getWorld().getName() + ".oreLimiter", true)) {
-            return;
-        }
+        OreLimiter.Type oreLimiter = OreLimiter.Type.valueOf(settings.getWorlds().getString(
+                event.getWorld().getName() + ".oreLimiter", OreLimiter.Type.NONE.name()));
 
         Chunk chunk = event.getChunk();
         Set<Block> checked = Sets.newHashSet();
@@ -58,14 +94,14 @@ public class OreLimiter implements Listener {
 
                     Material type = block.getType();
 
-                    if (!ORE_RATES.containsKey(type)) {
+                    if (!LIMITED_ORES.contains(type)) {
                         continue;
                     }
 
                     List<Block> vein = BlockUtils.getVein(block);
                     checked.addAll(vein);
 
-                    if (ORE_RATES.get(type) > random.nextDouble()) {
+                    if (random.nextDouble() > oreLimiter.getOreRemovalChance()) {
                         continue;
                     }
 
@@ -73,7 +109,5 @@ public class OreLimiter implements Listener {
                 }
             }
         }
-
-        */
     }
 }


### PR DESCRIPTION
As usual, copied from commit:

- Introduced OreLimiter.Type: NONE, MINOR, LESS_VEINS, SMALLER_VEINS
- NONE Is unavailable in WorldCreatorGUI (only used for arena world)
- MINOR is displayed as "None" in GUIs (players will complain if you even mention 20% ore limiting...)
- Ore limiter type is explained in GameInfoGUI and WorldCreatorGUI